### PR TITLE
Update Context#fail! for Ruby 2.7

### DIFF
--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -15,7 +15,7 @@ module Interactor
     end
 
     def fail!(context = {})
-      modifiable.update(context)
+      context.each { |key, value| modifiable[key.to_sym] = value }
       @failure = true
       raise Failure
     end


### PR DESCRIPTION
`modifiable` was removed in Ruby 2.7 https://github.com/ruby/ruby/commit/dbcc224f3883c810049ef620fac8a1b59bde2e69#

Updating the code to align with what the original gem has https://github.com/collectiveidea/interactor/pull/169

Already tested in instacart/shoppers app, it works well.